### PR TITLE
Refactor autotweet increment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,9 @@ GEM
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (1.0.0)
-    mimemagic (0.3.6)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)

--- a/app/controllers/automated_tweets_controller.rb
+++ b/app/controllers/automated_tweets_controller.rb
@@ -7,6 +7,13 @@ class AutomatedTweetsController < ApplicationController
 	
 	def new
 		@collection = ["famous last words", "most interesting man in the world", "yoda"]
+		@runtime = {
+								"5 minutes / 5 tweets" => 5,
+		            "10 minutes / 10 tweets" => 10,
+		            "25 minutes / 25 tweets" => 25,
+		            "50 minutes / 50 tweets" => 50,
+		            "100 minutes / 100 tweets" => 100
+								}
 		@automated_tweet = AutomatedTweet.new
 	end
 
@@ -33,6 +40,6 @@ class AutomatedTweetsController < ApplicationController
 	private
 
 	def automated_tweet_params
-		params.require(:automated_tweet).permit(:twitter_account_id, :body, :stop_at, :post_interval)
+		params.require(:automated_tweet).permit(:twitter_account_id, :body, :total_tweets)
 	end
 end

--- a/app/models/automated_tweet.rb
+++ b/app/models/automated_tweet.rb
@@ -3,16 +3,10 @@ class AutomatedTweet < ApplicationRecord
 	belongs_to :twitter_account
 
 	validates_presence_of :body
-	validates :stop_at, presence: true
-  validates :stop_at, inclusion: { in: (Time.current..Time.current+5.years) }
 
 	enum status: [:in_progress, :completed]
 
 	after_create :timed_publish!
-
-	after_initialize do
-		self.stop_at ||= 24.hours.from_now
-	end
 
 	def publish_to_twitter!
 		twitter_account.client.update(tweet_content)
@@ -20,12 +14,8 @@ class AutomatedTweet < ApplicationRecord
 		change_status_to_completed
 	end
 
-	def total_tweets
-		((self.stop_at - self.created_at) / 60)
-	end
-
 	def change_status_to_completed
-		if self.tweet_count == total_tweets.round
+		if self.tweet_count == self.total_tweets
 			self.update(status: 1)
 		end
 	end
@@ -46,11 +36,8 @@ class AutomatedTweet < ApplicationRecord
 	end
 
 	def timed_publish!
-		# Change time publish to use an amount of hours run instead of a start and stop time.
-		# user inputs 24 hours, it runs for 24 hours. (or minutes)
 		tweet_count = 0
-		total_hours = ((self.stop_at - self.created_at) / 60).round(0)
-		total_hours.times do
+		self.total_tweets.times do
 			AutoTweetJob.set(wait_until: tweet_count.minutes.from_now).perform_later(self)
 			tweet_count += 1
 		end

--- a/app/views/automated_tweets/_automated_tweet.html.erb
+++ b/app/views/automated_tweets/_automated_tweet.html.erb
@@ -9,33 +9,73 @@
         Theme: <%= automated_tweet.body %><br>
 
         <% if automated_tweet.completed? %>
-          This operation ran for <%= automated_tweet.total_tweets.round(0) %> hours.<br>
-          <%= automated_tweet.total_tweets.round(0) %> tweets posted. <br>
+          This operation ran for <%= automated_tweet.total_tweets %> minutes.<br>
+          <%= automated_tweet.total_tweets %> tweets posted. <br>
           Click <%= link_to "here", "https://twitter.com/#{automated_tweet.twitter_account.username}", target: :_blank %> to see your tweets.
         <% else %>
-          Running until <%= l automated_tweet.stop_at, format: :long %><br>
+          Status: <%= automated_tweet.status.titleize %><br>
+          <span class="progress-value">0</span> / <%= automated_tweet.total_tweets %> tweets posted.
 
-          <%= automated_tweet.tweet_count %> / <%= automated_tweet.total_tweets.ceil %> tweets posted.
-
-          <div class="progress progress-striped active">
-            <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-              <%= automated_tweet.tweet_count %>
+          <div class="progress" style="height: 20px;">
+            <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+              <div class="progress-value">0</div>
             </div>
           </div>
 
           <script>
-            valuer = 0;
+
+            window.addEventListener("load", loadExistingData);
+            totalTweetCount = parseInt(`<%= automated_tweet.total_tweets.to_i %>`);
+            percentageTick = parseInt(`<%= 100 / automated_tweet.total_tweets.ceil %>`)
+            tweetCount = parseInt(`<%= automated_tweet.tweet_count %>`)
+
+            function loadExistingData() {
+              var storedPercentage = localStorage.getItem('percentage')
+              getPercentage = JSON.parse(storedPercentage);
+              currentPercentage = getPercentage;
+              $('.progress-bar').css('width', currentPercentage+'%').attr('aria-valuenow', currentPercentage);
+
+              var getValue = localStorage.getItem('value');
+              var value = JSON.parse(getValue);
+              if (!value) {
+                  value = -1
+              }
+              updateValues(value)
+            }
 
             function addProgress(){
-                if ((`<%= 1 + automated_tweet.tweet_count %>`) === (`<%= automated_tweet.total_tweets.ceil %>`)) {
-                  window.location.reload();
-                } else {
-                  valuer = valuer + parseInt(`<%= 100 / automated_tweet.total_tweets.ceil %>`);
-                  $('.progress-bar').css('width', valuer+'%').attr('aria-valuenow', valuer);
-                  }
-                }
-          </script>
+              currentPercentage = currentPercentage + percentageTick;
 
+              var newPercentage = JSON.stringify(currentPercentage);
+
+              localStorage.setItem("percentage", newPercentage)
+
+              $('.progress-bar').css('width', currentPercentage+'%').attr('aria-valuenow', currentPercentage);
+              updateValues()
+
+              if (currentPercentage === 100) {
+                  window.location.reload();
+                  localStorage.clear();
+              }
+            }
+
+            function updateValues(currentValue = 0) {
+              var value = document.getElementsByClassName('progress-value');
+              [...value].forEach((el) => {
+                if (currentValue === 0) {
+                  var number = el.innerHTML;
+                  number ++;
+                  localStorage.setItem("value", number);
+                  el.innerHTML = number;
+                } else if (currentValue === -1){
+                    el.innerHTML = 0
+                } else {
+                  el.innerHTML = currentValue;
+                }
+              });
+            }
+
+          </script>
 
       </div>
     <% end %>

--- a/app/views/automated_tweets/new.html.erb
+++ b/app/views/automated_tweets/new.html.erb
@@ -15,12 +15,9 @@
   </div>
 
   <div class="mb-3">
-      <%= f.label :stop_at %>
-    <div class="form-control">
-      <%= f.datetime_select :stop_at %>
-    </div>
+    <%= f.label :tweet_amount %>
+    <%= f.collection_select :total_tweets, @runtime, :last, :first, {}, {autofocus: 'true', class: "form-control"} %>
   </div>
-
 
   <div class="mb-3">
     <%= f.submit class: "btn btn-primary"%>

--- a/db/migrate/20210421174141_add_total_tweets.rb
+++ b/db/migrate/20210421174141_add_total_tweets.rb
@@ -1,0 +1,7 @@
+class AddTotalTweets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :automated_tweets, :total_tweets, :integer, default: 0
+    remove_column :automated_tweets, :post_interval, :integer
+    remove_column :automated_tweets, :stop_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_01_015327) do
+ActiveRecord::Schema.define(version: 2021_04_21_174141) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,12 +19,11 @@ ActiveRecord::Schema.define(version: 2021_02_01_015327) do
     t.bigint "user_id"
     t.bigint "twitter_account_id"
     t.string "body"
-    t.datetime "stop_at"
-    t.integer "post_interval"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "status", default: 0
     t.integer "tweet_count", default: 0
+    t.integer "total_tweets", default: 0
     t.index ["twitter_account_id"], name: "index_automated_tweets_on_twitter_account_id"
     t.index ["user_id"], name: "index_automated_tweets_on_user_id"
   end


### PR DESCRIPTION
## Purpose
This pull request changes automated tweet creation by removing the tweet interval `stop_at` dropdown and instead adds a hard-coded solution that allows for tweet intervals in minutes.

This PR also adds a working javascript progress bar that saves progress in local storage upon refresh 


## Learning
My goal to add a working progress bar led me to learn the fundamentals of javascript, how local storage works, and ultimately how to trigger javascript functions on subscription through actioncable


